### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Spring and Hibernate for Beginners (Includes Spring Boot)
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fdarbyluv2code%2Fspring-and-hibernate-for-beginners&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
 
 Source code for the course: [Spring and Hibernate for Beginners (Includes Spring Boot)](http://www.luv2code.com/spring-github)
 


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

![Screenshot (1664)](https://user-images.githubusercontent.com/47092464/98453539-41a35900-2195-11eb-8259-3bd95dbcfc6c.png)
